### PR TITLE
Enable launch in single command

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "Build datasets using natural language"
 authors = [
     {name = "davidberenstein1957", email = "david.m.berenstein@gmail.com"},
 ]
-tags = [
+keywords = [
     "gradio",
     "synthetic-data",
     "huggingface",

--- a/src/synthetic_dataset_generator/__main__.py
+++ b/src/synthetic_dataset_generator/__main__.py
@@ -1,0 +1,4 @@
+if __name__ == "__main__":
+    from synthetic_dataset_generator import launch
+
+    launch()


### PR DESCRIPTION
By putting app.py in `__main__.py` you can do installing and launching the app in a single command, e.g.:

```
pipx run synthetic-dataset-generator
```
or 
```
uvx synthetic-dataset-generator
```

Background: https://packaging.python.org/en/latest/guides/creating-command-line-tools/


Also my editor complained that tags is not a valid keyword for [project] in pyproject.toml, I believe it should be keywords:
https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#keywords